### PR TITLE
Fall back to user config directory

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: nb_config_manager
-  version: "0.1.1"
+  version: "0.1.2"
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}

--- a/nb_config_manager/nb_config_manager.py
+++ b/nb_config_manager/nb_config_manager.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from errno import EACCES
 from os.path import exists, join
 
 from notebook.services.config.manager import ConfigManager
 from jupyter_core.paths import jupyter_config_dir, ENV_CONFIG_PATH
 
 from traitlets import Bool
+
 
 class EnvironmentConfigManager(ConfigManager):
     """Config Manager used for storing notebook frontend config
@@ -19,6 +21,7 @@ class EnvironmentConfigManager(ConfigManager):
 
     user_config_dir = join(jupyter_config_dir(), 'nbconfig')
     environment_config_dir = join(ENV_CONFIG_PATH[0], 'nbconfig')
+    default_config_dir = environment_config_dir
 
     def __init__(self, **kwargs):
         super(EnvironmentConfigManager, self).__init__(**kwargs)
@@ -47,18 +50,31 @@ class EnvironmentConfigManager(ConfigManager):
             else:
                 cfg_environment["load_extensions"] = user_extensions
 
+        try:
+            # try to write updated environment config
             self.update(section_name, cfg_environment)
+        except IOError as ex:
+            if ex.errno == EACCES:
+                # for example, if environment config dir is read-only.
+                # write to user config location instead.
+                cfg_user["load_extensions"] = cfg_environment.get("load_extensions")
+                self.config_dir = self.user_config_dir
+                self.update(section_name, cfg_user)
+
+                # leave config dir pointing here after loading config
+                self.default_config_dir = self.user_config_dir
+            else:
+                raise
 
     def _update_env_config(self):
-        "Update the three section in the environment space with the user info"
-        if exists(self.environment_config_dir): # otherwise defaults to user config
+        """Update the three section in the environment space with the user info"""
+        if exists(self.environment_config_dir):  # otherwise defaults to user config
             if exists(self.user_config_dir) and not self.disable_user_config:
                 # update the three sections
                 self._update_sections("notebook")
                 self._update_sections("tree")
                 self._update_sections("editor")
-            default_config_dir = self.environment_config_dir
         else:
-            default_config_dir = self.user_config_dir
+            self.default_config_dir = self.user_config_dir
 
-        self.config_dir = default_config_dir
+        self.config_dir = self.default_config_dir

--- a/nb_config_manager/nb_config_manager.py
+++ b/nb_config_manager/nb_config_manager.py
@@ -7,7 +7,7 @@ from notebook.services.config.manager import ConfigManager
 from jupyter_core.paths import jupyter_config_dir, ENV_CONFIG_PATH
 
 from traitlets import Bool
-
+from tornado.log import app_log as log
 
 class EnvironmentConfigManager(ConfigManager):
     """Config Manager used for storing notebook frontend config
@@ -57,6 +57,8 @@ class EnvironmentConfigManager(ConfigManager):
             if ex.errno == EACCES:
                 # for example, if environment config dir is read-only.
                 # write to user config location instead.
+                log.warn('Environment directory %s not writeable. Saving to user directory %s instead.',
+                         self.environment_config_dir, self.user_config_dir)
                 cfg_user["load_extensions"] = cfg_environment.get("load_extensions")
                 self.config_dir = self.user_config_dir
                 self.update(section_name, cfg_user)


### PR DESCRIPTION
This PR handles the case where the environment config directory is not writeable. The fallback is to write the merged nbextension list into the user config location, and make that the active config location in case any other notebook components need to write config data.

@damianavila 
