### PR TITLE
windows python path for conda recipe windows scripts

### DIFF
--- a/conda.recipe/post-link.bat
+++ b/conda.recipe/post-link.bat
@@ -1,1 +1,1 @@
-"%PREFIX%\bin\python" -m nb_config_manager.install --enable --prefix="%PREFIX%"
+"%PREFIX%\python" -m nb_config_manager.install --enable --prefix="%PREFIX%"

--- a/conda.recipe/pre-unlink.bat
+++ b/conda.recipe/pre-unlink.bat
@@ -1,1 +1,1 @@
-"%PREFIX%\bin\python" -m nb_config_manager.install --disable --prefix="%PREFIX%"
+"%PREFIX%\python" -m nb_config_manager.install --disable --prefix="%PREFIX%"


### PR DESCRIPTION
I know it is a minor correction but it was useful in my afternoon tests.
I did not solve it, it is just a copy of Anaconda-Server/nb_conda_kernels#5

Thanks for all the work.